### PR TITLE
Add a janitor_version=1.4 to the dns config env section

### DIFF
--- a/dns/dns.conf
+++ b/dns/dns.conf
@@ -44,7 +44,7 @@ start_timeout = 1m
 
 [container#janitor]
 type = oci
-image = opensvc/pdns_janitor:1.4
+image = opensvc/pdns_janitor:{env.janitor_version}
 netns = host
 userns = host
 rm = true
@@ -58,3 +58,5 @@ disable = true
 
 [env]
 server_port = 5300
+janitor_version = 1.4
+


### PR DESCRIPTION
So a v3 janitor can be easily deployed with:

om system/svc/dns deploy --config dns/dns.conf --env janitor_version=3
